### PR TITLE
Error Interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ example
 release/*
 golang-crosscompile/
 .project
+glide.lock
 
 # Created by https://www.gitignore.io
 
@@ -272,7 +273,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings 
+# TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: go
 go:
-  - 1.5
+  - 1.6
 before_install:
   - go get github.com/Masterminds/glide
   - glide up
 script:
-  - go install $(glide nv)
+  - go install
+  - go test -v

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,3 +4,5 @@ import:
     ref:     feature/logrus-aware-types
     repo:    https://github.com/akutz/logrus
     vcs:     git
+  - package: gopkg.in/gemnasium/logrus-airbrake-hook.v2
+    vcs:     git

--- a/goof_test.go
+++ b/goof_test.go
@@ -1,0 +1,52 @@
+package goof
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMarshalToJSONSansMessage(t *testing.T) {
+	e := WithFields(map[string]interface{}{
+		"resourceID": 123,
+	}, "invalid resource ID")
+	buf, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(string(buf))
+}
+
+func TestMarshalIndentToJSONSansMessage(t *testing.T) {
+	e := WithFields(map[string]interface{}{
+		"resourceID": 123,
+	}, "invalid resource ID")
+	buf, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(string(buf))
+}
+
+func TestMarshalToJSONWithMessage(t *testing.T) {
+	e := WithFields(map[string]interface{}{
+		"resourceID": 123,
+	}, "invalid resource ID")
+	e.IncludeMessageInJSON(true)
+	buf, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(string(buf))
+}
+
+func TestMarshalIndentToJSONWithMessage(t *testing.T) {
+	e := WithFields(map[string]interface{}{
+		"resourceID": 123,
+	}, "invalid resource ID")
+	e.IncludeMessageInJSON(true)
+	buf, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(string(buf))
+}


### PR DESCRIPTION
This patch introduces the Error interface which can be used to access the properties of a Goof Error.
