### PR TITLE
Fixes Marshaling Bug w Message Only

### DIFF
--- a/goof.go
+++ b/goof.go
@@ -277,6 +277,10 @@ func (e *Goof) GetLogData() map[string]interface{} {
 // MarshalJSON marshals this object to JSON for the encoding/json package.
 func (e *Goof) MarshalJSON() ([]byte, error) {
 
+	if len(e.Fields()) == 0 {
+		return json.Marshal(e.Error())
+	}
+
 	var m map[string]interface{}
 
 	if e.includeMsgInJSON {


### PR DESCRIPTION
This patch fixes a bug where Goof errors are not properly marshaled if only a message is supplied instead of any fields.
