### PR TITLE
Error Messages May Now Include Fields

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -3,6 +3,5 @@ import:
   - package: github.com/Sirupsen/logrus
     ref:     feature/logrus-aware-types
     repo:    https://github.com/akutz/logrus
-    vcs:     git
   - package: gopkg.in/gemnasium/logrus-airbrake-hook.v2
-    vcs:     git
+  - package: github.com/stretchr/testify

--- a/goof.go
+++ b/goof.go
@@ -179,14 +179,39 @@ regarding the context of the error and that may be helpful to debugging.
 package goof
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"strconv"
 )
 
-// InnerErrorKey is the key used to store inner errors in Goof errors.
-var InnerErrorKey = "inner"
+var (
+	// IncludeMessageInJSON sets a flag indicating whether or not to include
+	// the error message when serializing a Goof.Error to JSON. New errors
+	// will have their own IncludeMessageInJSON flag initialized to this value.
+	IncludeMessageInJSON bool
 
-// Error is a structure that implements the Go Error interface as well as the
+	// IncludeFieldsInError sets a flag indicating whether or not to include
+	// the fields with the string returned by the Error function. New errors
+	// will have their own IncludeFieldsInError flag initialized to this value.
+	IncludeFieldsInError bool
+
+	// IncludeFieldsInFormat sets a flag indicating whether or not to include
+	// the fields with the string returned by the Format function. New errors
+	// will have their own IncludeFieldsInFormat flag initialized to this value.
+	IncludeFieldsInFormat bool
+
+	// IncludeFieldsInString sets a flag indicating whether or not to include
+	// the fields with the string returned by the String function. New errors
+	// will have their own IncludeFieldsInString flag initialized to this value.
+	IncludeFieldsInString bool
+
+	// InnerErrorKey is the key used to store inner errors in Goof errors.
+	InnerErrorKey = "inner"
+)
+
+// Error is Goof error and implements the Go Error interface as well as the
 // Golf interface for extended log information capabilities.
 type Error interface {
 	error
@@ -202,6 +227,9 @@ type Error interface {
 	// fmt.Stringer guarantees the Error will have a String function
 	fmt.Stringer
 
+	// fmt.Formatter guarantees the Error will have a Format function.
+	fmt.Formatter
+
 	// json.Marshaller indicates that this type controls how it is marshalled to
 	// JSON using the encoding/json package.
 	json.Marshaler
@@ -212,13 +240,27 @@ type Error interface {
 	// IncludeMessageInJSON sets a flag indicating whether or not to include
 	// the error message when serializing a Goof.Error to JSON.
 	IncludeMessageInJSON(enable bool)
+
+	// IncludeFieldsInError sets a flag indicating whether or not to include
+	// the fields with the string returned by the Error function.
+	IncludeFieldsInError(enable bool)
+
+	// IncludeFieldsInFormat sets a flag indicating whether or not to include
+	// the fields with the string returned by the Format function.
+	IncludeFieldsInFormat(enable bool)
+
+	// IncludeFieldsInString sets a flag indicating whether or not to include
+	// the fields with the string returned by the String function.
+	IncludeFieldsInString(enable bool)
 }
 
-// Goof is a goof error.
-type Goof struct {
-	msg              string
-	data             map[string]interface{}
-	includeMsgInJSON bool
+type goof struct {
+	msg                   string
+	data                  map[string]interface{}
+	includeMsgInJSON      bool
+	includeFieldsInError  bool
+	includeFieldsInString bool
+	includeFieldsInFormat bool
 }
 
 // logrusAware enables the Goof error to be logged correctly by logrus at
@@ -238,108 +280,191 @@ type golfer interface {
 // Fields is a type alias for a map of interfaces.
 type Fields map[string]interface{}
 
-// Error returns the error message.
-func (e *Goof) Error() string {
-	return e.msg
-}
-
 // Fields returns the error's structured, field data.
-func (e *Goof) Fields() map[string]interface{} {
+func (e *goof) Fields() map[string]interface{} {
 	return e.data
 }
 
+// Error returns the error message.
+func (e *goof) Error() string {
+	return e.getMessage(e.includeFieldsInError)
+}
+
 // String returns a stringified version of the error.
-func (e *Goof) String() string {
-	return e.msg
+func (e *goof) String() string {
+	return e.getMessage(e.includeFieldsInString)
+}
+
+// Format may call Sprint(f) or Fprint(f) etc. to generate its output.
+func (e *goof) Format(f fmt.State, c rune) {
+	s := e.getMessage(e.includeFieldsInFormat)
+	fs := &bytes.Buffer{}
+	fs.WriteRune('%')
+	if f.Flag('+') {
+		fs.WriteRune('+')
+	}
+	if f.Flag('-') {
+		fs.WriteRune('-')
+	}
+	if f.Flag('#') {
+		fs.WriteRune('#')
+	}
+	if f.Flag(' ') {
+		fs.WriteRune(' ')
+	}
+	if f.Flag('0') {
+		fs.WriteRune('0')
+	}
+	if w, ok := f.Width(); ok {
+		fs.WriteString(fmt.Sprintf("%d", w))
+	}
+	if p, ok := f.Precision(); ok {
+		fs.WriteString(fmt.Sprintf("%d", p))
+	}
+	fs.WriteRune(c)
+	fmt.Fprintf(f, fs.String(), s)
 }
 
 // PlayGolf lets the logrus framework know that Error supports the Golf
 // framework.
-func (e *Goof) PlayGolf() bool {
+func (e *goof) PlayGolf() bool {
 	return true
 }
 
 // GolfExportedFields returns the fields to use when playing golf.
-func (e *Goof) GolfExportedFields() map[string]interface{} {
+func (e *goof) GolfExportedFields() map[string]interface{} {
 	return e.data
 }
 
 // GetLogMessage gets the message used for logging for this object.
-func (e *Goof) GetLogMessage() string {
+func (e *goof) GetLogMessage() string {
 	return e.msg
 }
 
 // GetLogData gets the message used for logging for this object.
-func (e *Goof) GetLogData() map[string]interface{} {
+func (e *goof) GetLogData() map[string]interface{} {
 	return e.data
 }
 
 // MarshalJSON marshals this object to JSON for the encoding/json package.
-func (e *Goof) MarshalJSON() ([]byte, error) {
+func (e *goof) MarshalJSON() ([]byte, error) {
 
 	if len(e.Fields()) == 0 {
 		return json.Marshal(e.Error())
 	}
 
-	var m map[string]interface{}
+	m := e.Fields()
 
 	if e.includeMsgInJSON {
 		m = map[string]interface{}{
 			"error":  e.Error(),
 			"fields": e.Fields(),
 		}
-	} else {
-		m = e.Fields()
 	}
 
 	return json.Marshal(m)
 }
 
+var (
+	dublQuoteRX = regexp.MustCompile(`^"(.*)"$`)
+	snglQuoteRX = regexp.MustCompile(`^'(.*)'$`)
+	backQuoteRX = regexp.MustCompile("^`(.*)`$")
+	containsWS  = regexp.MustCompile(`\s`)
+)
+
+func (e *goof) getMessage(includeFields bool) string {
+
+	if !includeFields {
+		return e.msg
+	}
+
+	buf := &bytes.Buffer{}
+	fmt.Fprintf(buf, "msg=%q", e.msg)
+
+	for k, v := range e.data {
+		sv := fmt.Sprintf("%v", v)
+		if m := dublQuoteRX.FindStringSubmatch(sv); len(m) > 0 {
+			sv = m[1]
+		} else if m := snglQuoteRX.FindStringSubmatch(sv); len(m) > 0 {
+			sv = m[1]
+		} else if m := backQuoteRX.FindStringSubmatch(sv); len(m) > 0 {
+			sv = m[1]
+		}
+		if containsWS.MatchString(k) {
+			k = strconv.Quote(k)
+		}
+		if containsWS.MatchString(sv) {
+			sv = strconv.Quote(sv)
+		}
+		fmt.Fprintf(buf, " %s=%s", k, sv)
+	}
+
+	return buf.String()
+}
+
 // IncludeMessageInJSON sets a flag indicating whether or not to include
 // the error message when serializing a Goof.Error to JSON.
-func (e *Goof) IncludeMessageInJSON(enable bool) {
+func (e *goof) IncludeMessageInJSON(enable bool) {
 	e.includeMsgInJSON = enable
 }
 
+// IncludeFieldsInError sets a flag indicating whether or not to include
+// the fields with the string returned by the Error function.
+func (e *goof) IncludeFieldsInError(enable bool) {
+	e.includeFieldsInError = enable
+}
+
+// IncludeFieldsInFormat sets a flag indicating whether or not to include
+// the fields with the string returned by the Format function.
+func (e *goof) IncludeFieldsInFormat(enable bool) {
+	e.includeFieldsInFormat = enable
+}
+
+// IncludeFieldsInString sets a flag indicating whether or not to include
+// the fields with the string returned by the String function.
+func (e *goof) IncludeFieldsInString(enable bool) {
+	e.includeFieldsInString = enable
+}
+
 // New returns a new error object initialized with the provided message.
-func New(message string) error {
+func New(message string) Error {
 	return WithError(message, nil)
 }
 
 // Newf returns a new error object initialized with the messages created by
 // formatting the format string with the provided arguments.
-func Newf(format string, a ...interface{}) error {
+func Newf(format string, a ...interface{}) Error {
 	return WithError(fmt.Sprintf(format, a), nil)
 }
 
 // WithError returns a new error object initialized with the provided message
 // and inner error.
-func WithError(message string, inner error) *Goof {
+func WithError(message string, inner error) Error {
 	return WithFieldsE(nil, message, inner)
 }
 
 // WithField returns a new error object initialized with the provided field
 // name, value, and error message.
-func WithField(key string, val interface{}, message string) *Goof {
+func WithField(key string, val interface{}, message string) Error {
 	return WithFields(Fields{key: val}, message)
 }
 
 // WithFieldE returns a new error object initialized with the provided field
 // name, value, error message, and inner error.
-func WithFieldE(key string, val interface{}, message string, inner error) *Goof {
+func WithFieldE(key string, val interface{}, message string, inner error) Error {
 	return WithFieldsE(Fields{key: val}, message, inner)
 }
 
 // WithFields returns a new error object initialized with the provided fields
 // and error message.
-func WithFields(fields map[string]interface{}, message string) *Goof {
+func WithFields(fields map[string]interface{}, message string) Error {
 	return WithFieldsE(fields, message, nil)
 }
 
 // WithFieldsE returns a new error object initialized with the provided fields,
 // error message, and inner error.
 func WithFieldsE(
-	fields map[string]interface{}, message string, inner error) *Goof {
+	fields map[string]interface{}, message string, inner error) Error {
 
 	if fields == nil {
 		fields = Fields{}
@@ -348,15 +473,12 @@ func WithFieldsE(
 		fields[InnerErrorKey] = inner
 	}
 
-	return &Goof{
-		msg:              message,
-		data:             fields,
-		includeMsgInJSON: false,
+	return &goof{
+		msg:                   message,
+		data:                  fields,
+		includeMsgInJSON:      IncludeMessageInJSON,
+		includeFieldsInError:  IncludeFieldsInError,
+		includeFieldsInFormat: IncludeFieldsInFormat,
+		includeFieldsInString: IncludeFieldsInString,
 	}
-}
-
-// newError is not meant to be called by anyone, it's just here to assert that
-// the Goof struct adheres to the Error interface.
-func newError() Error {
-	return &Goof{}
 }

--- a/goof_test.go
+++ b/goof_test.go
@@ -2,17 +2,65 @@ package goof
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func TestFormat(t *testing.T) {
+	e := WithField("hello", "world", "introduction error")
+	assert.EqualValues(t, "introduction error", fmt.Sprint(e))
+	assert.EqualValues(t, "introduction error", fmt.Sprintf("%s", e))
+	assert.EqualValues(t, `"introduction error"`, fmt.Sprintf("%q", e))
+	assert.EqualValues(t, "`introduction error`", fmt.Sprintf("%#q", e))
+	assert.EqualValues(t, "       introduction error", fmt.Sprintf("%25s", e))
+	assert.EqualValues(t, "introduction error       ", fmt.Sprintf("%-25s", e))
+	assert.EqualValues(t, `     "introduction error"`, fmt.Sprintf("%25q", e))
+	assert.EqualValues(t, `"introduction error"     `, fmt.Sprintf("%-25q", e))
+	assert.EqualValues(t, "     `introduction error`", fmt.Sprintf("%#25q", e))
+	assert.EqualValues(t, "`introduction error`     ", fmt.Sprintf("%-#25q", e))
+	assert.EqualValues(t, "`introduction error`     ", fmt.Sprintf("%#-25q", e))
+
+	assertMsgAndString(t, e, false, false, false)
+	assertMsgAndString(t, e, true, false, false)
+}
+
+func TestError(t *testing.T) {
+	e := WithField("hello", "world", "introduction error")
+	assertMsgAndString(t, e, false, false, false)
+	assertMsgAndString(t, e, false, true, false)
+}
+
+func TestString(t *testing.T) {
+	e := WithField("hello", "world", "introduction error")
+	assertMsgAndString(t, e, false, false, false)
+	assertMsgAndString(t, e, false, false, true)
+}
+
+func assertMsgAndString(t *testing.T, e Error, incErr, incFmt, incStr bool) {
+	e.IncludeFieldsInError(incErr)
+	e.IncludeFieldsInFormat(incFmt)
+	e.IncludeFieldsInString(incStr)
+	assertMsgAndStringActual(t, e.Error(), incErr)
+	assertMsgAndStringActual(t, e.String(), incStr)
+	assertMsgAndStringActual(t, fmt.Sprintf("%s", e), incFmt)
+}
+
+func assertMsgAndStringActual(t *testing.T, actual string, inc bool) {
+	if inc {
+		assert.EqualValues(t, `msg="introduction error" hello=world`, actual)
+	} else {
+		assert.EqualValues(t, "introduction error", actual)
+	}
+}
 
 func TestMarshalToJSONSansMessage(t *testing.T) {
 	e := WithFields(map[string]interface{}{
 		"resourceID": 123,
 	}, "invalid resource ID")
 	buf, err := json.Marshal(e)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	t.Log(string(buf))
 }
 
@@ -21,9 +69,7 @@ func TestMarshalIndentToJSONSansMessage(t *testing.T) {
 		"resourceID": 123,
 	}, "invalid resource ID")
 	buf, err := json.MarshalIndent(e, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	t.Log(string(buf))
 }
 
@@ -33,9 +79,7 @@ func TestMarshalToJSONWithMessage(t *testing.T) {
 	}, "invalid resource ID")
 	e.IncludeMessageInJSON(true)
 	buf, err := json.Marshal(e)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	t.Log(string(buf))
 }
 
@@ -45,8 +89,6 @@ func TestMarshalIndentToJSONWithMessage(t *testing.T) {
 	}, "invalid resource ID")
 	e.IncludeMessageInJSON(true)
 	buf, err := json.MarshalIndent(e, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	t.Log(string(buf))
 }


### PR DESCRIPTION
This patch enhances Goof with the flags IncludeFieldsInError, IncludeFieldsInFormat, and IncludeFieldsInString. These flags are available globally and per-Error instance. When enabled, these flags will include an error's fields inside of the emitted error message. This will provide a central way to ensure that inner errors and error field data is emitted to projects that don't specifically extract it via other means.
