### PR TITLE
Add the Newe function

### DIFF
--- a/goof.go
+++ b/goof.go
@@ -445,6 +445,36 @@ func Newf(format string, a ...interface{}) Goof {
 	return WithError(fmt.Sprintf(format, a), nil)
 }
 
+// Newe returns the provided error object wrapped as a Goof error and recurses
+// into any possible, inner errors and ensures they too are Goof errors.
+func Newe(err error) Goof {
+
+	// check to see if the provided error is already a Goof
+	gerr, ok := err.(Goof)
+
+	// if the provided error is not a Goof we need to
+	// wrap it as a Goof by creating a new Goof
+	// instance using the provided error's message
+	if !ok {
+		return New(err.Error())
+	}
+
+	// check to see if there is an inner error
+	ierr, ok := gerr.Fields()["inner"].(error)
+	if !ok {
+		return gerr
+	}
+
+	// recurse with the inner error
+	gerr.Fields()["inner"] = Newe(ierr)
+	return gerr
+}
+
+// Inner is an alias for Newe.
+func Inner(err error) Goof {
+	return Newe(err)
+}
+
 // WithError returns a new error object initialized with the provided message
 // and inner error.
 func WithError(message string, inner error) Goof {

--- a/goof_test.go
+++ b/goof_test.go
@@ -2,11 +2,46 @@ package goof
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestNewe(t *testing.T) {
+	g1 := WithError("g1", New("g2"))
+	buf, _ := json.Marshal(g1)
+	if !assert.Equal(t, `{"inner":"g2","msg":"g1"}`, string(buf)) {
+		t.FailNow()
+	}
+
+	g1 = WithError("g1", errors.New("g2"))
+	buf, _ = json.Marshal(g1)
+	if !assert.Equal(t, `{"inner":{},"msg":"g1"}`, string(buf)) {
+		t.FailNow()
+	}
+
+	g1 = Newe(g1)
+	buf, _ = json.Marshal(g1)
+	if !assert.Equal(t, `{"inner":"g2","msg":"g1"}`, string(buf)) {
+		t.FailNow()
+	}
+
+	g1 = WithError("g1", WithError("g2", errors.New("g3")))
+	buf, _ = json.Marshal(g1)
+	if !assert.Equal(
+		t, `{"inner":{"inner":{},"msg":"g2"},"msg":"g1"}`, string(buf)) {
+		t.FailNow()
+	}
+
+	g1 = Newe(g1)
+	buf, _ = json.Marshal(g1)
+	if !assert.Equal(
+		t, `{"inner":{"inner":"g3","msg":"g2"},"msg":"g1"}`, string(buf)) {
+		t.FailNow()
+	}
+}
 
 func TestFormat(t *testing.T) {
 	e := WithField("hello", "world", "introduction error")


### PR DESCRIPTION
This patch adds the `Newe` function which enables wrapping an existing error as a Goof error. The function also recurses into existing Goof errors to wrap any inner errors that are not Goof errors as Goof instances. The `Newe` function has an alias, `Inner`.

This PR is related to codedellemc/libstorage#128.